### PR TITLE
Better mod compatibility for Operations

### DIFF
--- a/Source/Source/Harmony/JobGiver_Work_Patch.cs
+++ b/Source/Source/Harmony/JobGiver_Work_Patch.cs
@@ -50,7 +50,7 @@ namespace Hospitality.Harmony
 
             private static bool IsOperation(WorkGiver workGiver)
             {
-                return workGiver.def.workType == WorkTypeDefOf.Doctor && (workGiver.def.billGiversAllHumanlikes || workGiver.def.billGiversAllAnimals);
+                return workGiver is WorkGiver_DoBill && (workGiver.def.billGiversAllHumanlikes || workGiver.def.billGiversAllAnimals);
             }
 
             private static bool IsSkilledEnough(Pawn pawn, WorkTypeDef workTypeDef)


### PR DESCRIPTION
IsOperation checks for WorkGiver_DoBill instead of Doctor work type

Specifically, [Job Splitter](https://steamcommunity.com/sharedfiles/filedetails/?id=1211661009&tscn=1541049726) changes operations to a separate "Surgery" type, which Hospitality would not recognize and allow guests to operate when the setting was off.