### PR TITLE
Add config file for PriceFactor

### DIFF
--- a/Source/Source/JobDriver_BuyItem.cs
+++ b/Source/Source/JobDriver_BuyItem.cs
@@ -15,7 +15,7 @@ namespace Hospitality
         //Constants
         public const int MinShoppingDuration = 75;
         public const int MaxShoppingDuration = 300;
-        public const float PriceFactor = 0.85f;
+        public static float PriceFactor = 0.85f;
 
         //Properties
         protected Thing Item { get { return job.targetA.Thing; } }

--- a/Source/Source/Settings.cs
+++ b/Source/Source/Settings.cs
@@ -26,6 +26,37 @@ namespace Hospitality {
             maxGuestGroupSize = settings.GetHandle("maxGuestGroupSize", "MaxGuestGroupSize".Translate(), "MaxGuestGroupSizeDesc".Translate(), 16, GroupSizeLimits());
             disableLimits = settings.GetHandle("disableLimits", "DisableLimits".Translate(), "DisableLimitsDesc".Translate(), false);
             disableGuestsTab = settings.GetHandle("disableGuestsTab", "DisableGuestsTab".Translate(), "DisableGuestsTabDesc".Translate(), false);
+            
+            string hiddenConfigFile = Path.Combine(GenFilePaths.ConfigFolderPath, "Hospitality.cfg");
+            if (File.Exists(hiddenConfigFile))
+            {
+                try {
+                    var reader = File.OpenText(hiddenConfigFile);
+                    string line;
+                    while ((line = reader.ReadLine()) != null)
+                    {
+                        if (line.StartsWith("#")) continue;
+                        string[] keyVal = line.Split('=');
+                        if (keyVal.Length != 2) continue;
+                        string key = keyVal[0].Trim();
+                        string val = keyVal[1].Trim();
+
+                        switch (key)
+                        {
+                            case "PriceFactor":
+                                Log.Message("[Hospitality] Setting PriceFactor to " + val);
+                                JobDriver_BuyItem.PriceFactor = float.Parse(val);
+                                break;
+
+                            default:
+                                Log.Message("[Hospitality] Unrecognized setting: " + key);
+                                break;
+                        }
+                    }
+                } catch (Exception e) {
+                    Log.Error("[Hospitality] Exception loading Hospitality.cfg: " + e.Message);
+                }
+            }
         }
 
         private static SettingHandle.ValueIsValid WorkSkillLimits()


### PR DESCRIPTION
Adds a Hospitality.cfg file in the RimWorld Config/ directory for "hidden" settings which are considered too advanced to be given to regular users. It will not be created or overwritten by default, and will be silently ignored if it doesn't exist.

Use this config file to make the PriceFactor for guests buying items configurable.