### PR TITLE
Null check on Need Rest

### DIFF
--- a/Source/Source/IncidentWorker_VisitorGroup.cs
+++ b/Source/Source/IncidentWorker_VisitorGroup.cs
@@ -291,7 +291,9 @@ namespace Hospitality
                 if (GenSpawn.Spawn(pawn, CellFinder.RandomClosewalkCellNear(parms.spawnCenter, map, 5), map) is Pawn spawnedPawn)
                 {
                     spawnedPawn.needs.SetInitialLevels();
-                    spawnedPawn.needs.rest.CurLevel = Rand.Range(0.1f, 0.7f);
+                    if (spawnedPawn.needs != null && spawnedPawn.needs.rest != null) {
+                        spawnedPawn.needs.rest.CurLevel = Rand.Range(0.1f, 0.7f);
+                    }
                     spawned.Add(spawnedPawn);
                 }
             }


### PR DESCRIPTION
Prevents error "Visitors failed to spawn" due to custom Races which do not require the Need Rest (androids, mechanoids).