### PR TITLE
Replace "Ensure safety" with "Assure safety"

### DIFF
--- a/1.2/Languages/English/Keyed/Hospitality.xml
+++ b/1.2/Languages/English/Keyed/Hospitality.xml
@@ -39,7 +39,7 @@
 
   <VisitorsArrivedTitle>Visitors have arrived at {WORLDOBJECT_label} (from {1})</VisitorsArrivedTitle>
   <VisitorsArrivedDesc>They are afraid to enter your territory for the following reasons:\n{1}\n\nIf you send them away they will stay in the area and come back later.</VisitorsArrivedDesc>
-  <VisitorsArrivedAccept>Ensure safety</VisitorsArrivedAccept>
+  <VisitorsArrivedAccept>Assure safety</VisitorsArrivedAccept>
   <VisitorsArrivedRefuse>Send away</VisitorsArrivedRefuse>
   <VisitorsArrivedRefuseUntilBeds>Refuse visitors until I have guest beds</VisitorsArrivedRefuseUntilBeds>
   <VisitorsArrivedReasonNoBeds>No guest beds</VisitorsArrivedReasonNoBeds>


### PR DESCRIPTION
Ensure means active measures to establish safety: https://www.merriam-webster.com/dictionary/ensure

Assure is more appropriate here, since the option overrides the safety check but does not actually remove possible threats:  https://www.merriam-webster.com/dictionary/assure