### PR TITLE
Fix: Guests won't equip apparel that they buy

### DIFF
--- a/Source/Source/JobDriver_BuyItem.cs
+++ b/Source/Source/JobDriver_BuyItem.cs
@@ -95,7 +95,7 @@ namespace Hospitality
             }
 
             int tookItems;
-            if (thing.def.IsApparel && thing is Apparel apparel && !ApparelUtility.HasPartsToWear(pawn, apparel.def) && ItemUtility.AlienFrameworkAllowsIt(toil.actor.def, apparel.def, "CanWear"))
+            if (thing.def.IsApparel && thing is Apparel apparel && ApparelUtility.HasPartsToWear(pawn, apparel.def) && ItemUtility.AlienFrameworkAllowsIt(toil.actor.def, apparel.def, "CanWear"))
             {
                 toil.actor.apparel.Wear(apparel);
                 tookItems = apparel.stackCount;


### PR DESCRIPTION
Currently only pawns MISSING body parts would equip the things they buy