### PR TITLE
Fixes CE compat

### DIFF
--- a/Source/Source/Utilities/ItemUtility.cs
+++ b/Source/Source/Utilities/ItemUtility.cs
@@ -103,7 +103,7 @@ namespace Hospitality {
             var inventory = pawn.GetInventory();
             if (inventory == null) return current.stackCount;
 
-            object[] arguments = {current, 0, false, false};
+            object[] arguments = {current, 0, false, true};
 
             try
             {


### PR DESCRIPTION
Most CE pawns will be spawned with a backpack (or other bulk-adding clothing). Ignoring added offsets by apparel stunts the number of items a pawn can hold. Fixes https://github.com/CombatExtended-Continued/CombatExtended/issues/1056