### PR TITLE
Improved, less erratic silver on guests

### DIFF
--- a/Source/Source/IncidentWorker_VisitorGroup.cs
+++ b/Source/Source/IncidentWorker_VisitorGroup.cs
@@ -459,13 +459,11 @@ namespace Hospitality
                 float totalValue = 0;
 
                 // Money
-                //Log.Message("Goodwill: "+visitor.Faction.ColonyGoodwill);
-                var wealthBase = 25 + (visitor.Faction.HasGoodwill ? visitor.Faction.PlayerGoodwill : Rand.Range(25, 75));
+                var wealthBase = 10 + (visitor.Faction.HasGoodwill ? visitor.Faction.PlayerGoodwill / 2.0f : Rand.Range(0, 50)); // everyone travelling has at least 10s in their pocket
                 var title = visitor.royalty?.MostSeniorTitle;
-                if (title != null) wealthBase += title.def.seniority/2;
-                var amountS = Mathf.Max(0, Mathf.RoundToInt(Rand.Gaussian(wealthBase, wealthBase) * 2 * Settings.silverMultiplier * 0.1f)) + Rand.Range(0, 40);
-
-                if (amountS >= Rand.Range(10, 25))
+                if (title != null) wealthBase += title.def.seniority / 2.0f;
+                var amountS = Mathf.RoundToInt(((wealthBase + (visitor.ageTracker.AgeBiologicalYears / 5.0f)) * Settings.silverMultiplier)); // eldery can get better beds to compensate for their lower mood
+                if (amountS > 0)
                 {
                     var money = SpawnGroupUtility.CreateRandomItem(visitor, ThingDefOf.Silver);
                     money.stackCount = amountS;


### PR DESCRIPTION
I did many iterations of testing how the silver on pawn guests feels more "reliable" - because it was crazy random, as in you can not really plan your bed prices according to your goodwill with the visiting factions. Within one group the spread was too high.
So I made it more lineair with the goodwill. I bet 99% of the Hospitality users did not even know goodwill had anything to do with the silver on guests.
On top of that I tried to "soften" the hit you get of older people visiting together with the semi-randomness of age spread within a group. By giving them extra silver lineair to their age.
This results in a formula that people just about can get their head around, which they seem to appreciate more than pure randomness.