### PR TITLE
Fix dropping silver not working for a pokertable

### DIFF
--- a/Source/Source/CompVendingMachine.cs
+++ b/Source/Source/CompVendingMachine.cs
@@ -132,9 +132,9 @@ namespace Hospitality
 
         public override void PostDestroy(DestroyMode mode, Map previousMap)
         {
-            base.PostDestroy(mode, previousMap);
-            MainContainer.TryDropAll(parent.InteractionCell, previousMap, ThingPlaceMode.Near);
+            MainContainer.TryDropAll(parent.OccupiedRect().Cells.RandomElement(), previousMap, ThingPlaceMode.Near);
             MainContainer.ClearAndDestroyContents();
+            base.PostDestroy(mode, previousMap);
         }
     }
 


### PR DESCRIPTION
a pokertable has no single interactioncell and throws a NPE when destroyed and not dropping silver. I created a generic solution that should work for all buildings, it uses OccupiedRect and is similar how other components are dropped when a building is destroyed.
The parent method is called after the silver, not very important, it just changes the order: silver is dropped first and then other components, this is how it works for the cash register as well.