### PR TITLE
Fix guests losing their recreation need after loading a savegame

### DIFF
--- a/Source/Source/Patches/Pawn_NeedsTracker_Patch.cs
+++ b/Source/Source/Patches/Pawn_NeedsTracker_Patch.cs
@@ -20,7 +20,8 @@ namespace Hospitality.Patches
             [HarmonyPrefix]
             public static bool Prefix(ref bool __result, NeedDef nd, Pawn ___pawn)
             {
-                if ((nd == NeedDefOf.Joy || nd == defComfort || nd == defBeauty || nd == defSpace) && ___pawn.IsGuest()) // ADDED
+                if (___pawn.guest == null) return true;
+                if ((nd == NeedDefOf.Joy || nd == defComfort || nd == defBeauty || nd == defSpace) && ___pawn.guest.GuestStatus.Equals(GuestStatus.Guest))
                 {
                     __result = true;
                     return false;


### PR DESCRIPTION
It fixes the issue of guests losing their recreation need. But I have not enough knowledge of the history of how the guest system works and why there was a IsGuest method vs the vanilla gueststatus. Is it ok that everything that is a vanilla guest has these needs?
