### PR TITLE
Fix #845

### DIFF
--- a/Source/Source/MainTab/PawnColumnWorker_Relationship.cs
+++ b/Source/Source/MainTab/PawnColumnWorker_Relationship.cs
@@ -6,16 +6,14 @@ using static Hospitality.Utilities.RelationUtility;
 
 namespace Hospitality.MainTab;
 
-[StaticConstructorOnStartup]
 public class PawnColumnWorker_Relationship : PawnColumnWorker_Icon
 {
-    private static readonly Texture2D Icon = ContentFinder<Texture2D>.Get("UI/Tab/Relationship");
     private bool mayDrawLordGroups;
 
     public override Texture2D GetIconFor(Pawn pawn)
     {
         if (pawn == null) return null;
-        return GetRelationInfo(pawn).hasRelationship ? Icon : null;
+        return GetRelationInfo(pawn).hasRelationship ? HospitalityContent.RelationshipIcon : null;
     }
 
     public override string GetIconTip(Pawn pawn)

--- a/Source/Source/Utilities/HospitalityContent.cs
+++ b/Source/Source/Utilities/HospitalityContent.cs
@@ -10,5 +10,7 @@ namespace Hospitality.Utilities
         public static readonly Texture2D ButtonNumberDown = ContentFinder<Texture2D>.Get("UI/Commands/ButtonNumberDown");
         public static readonly Texture2D ButtonNumberAuto = ContentFinder<Texture2D>.Get("UI/Commands/ButtonNumberAuto");
 
+        public static readonly Texture2D RelationshipIcon = ContentFinder<Texture2D>.Get("UI/Tab/Relationship");
+
     }
 }


### PR DESCRIPTION
Accessing PawnColumnDef.Worker from certain Harmony patch classes can trigger an error, as RimWorld is still in its asynchronous data loading phase during that time.
`Tried to get a resource "UI/Tab/Relationship" from a different thread. All resources must be loaded in the main thread.`